### PR TITLE
fix setup, bump version

### DIFF
--- a/airbrake/__init__.py
+++ b/airbrake/__init__.py
@@ -5,7 +5,7 @@
     Client for sending python exceptions to airbrake.io
 """
 
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 __url__ = "https://github.com/airbrake/airbrake-python"
 _notifier = {
     'name': 'airbrake-python',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,19 @@
+import re
+import ast
 from setuptools import setup, find_packages
 
-from airbrake import __version__ as version
-from airbrake import __url__ as url
+
+_version_re = re.compile(r'__version__\s+=\s+(.*)')
+_url_re = re.compile(r'__url__\s+=\s+(.*)')
+
+
+with open('airbrake/__init__.py', 'rb') as f:
+    f = f.read()
+    version = str(ast.literal_eval(_version_re.search(
+        f.decode('utf-8')).group(1)))
+    url = str(ast.literal_eval(_url_re.search(
+        f.decode('utf-8')).group(1)))
+
 
 dependencies = [
     'requests>=2.2.1'


### PR DESCRIPTION
Reads the `__version__` and `__url__` variables without importing the package.
The import was causing a setup failure if `requests` was not already installed. 

Inspired by:
https://github.com/mitsuhiko/click/blob/master/setup.py#L9-L11

and

https://github.com/sigmavirus24/github3.py/blob/develop/setup.py#L34-L40
