### PR TITLE
Don't overwrite a custom message

### DIFF
--- a/airbrake/notifier.py
+++ b/airbrake/notifier.py
@@ -229,7 +229,7 @@ class Error(object):
             self.data.update(
                 {'type': self.exc_info[1].__class__.__name__,
                  'backtrace': format_backtrace(self.exc_info[2]),
-                 'message': tbmessage})
+                 'message': message or tbmessage})
         else:
             raise TypeError(
                 "Airbrake module (notifier.Error) received "


### PR DESCRIPTION
This updates the Error class such that it will not overwrite a custom message passed to it.
