### PR TITLE
Signature change as proposed in issue #16

### DIFF
--- a/airbrake/handler.py
+++ b/airbrake/handler.py
@@ -37,7 +37,7 @@ class AirbrakeHandler(logging.Handler):
         if isinstance(airbrake, Airbrake):
             self.airbrake = airbrake
         else:
-            self.airbrake = Airbrake(project_id=None, api_key=None, environment=None)
+            self.airbrake = Airbrake(project_id, api_key, environment)
 
     def emit(self, record):
         """Log the record airbrake.io style.


### PR DESCRIPTION
Exchanged the **kwargs with (positional) keyword arguments.

Rationale: Apparently the only way in Py3.4 to provide an argument
object for fileConfig() and _install_handlers() from the namespace
logging. Said _install_handlers() erroneously initialises handlers only
via vararg unpacking (_args) but failes to unpack kwarg (...,_*kwargs).

(This time I used a proper branch. Sorry for my cluttering)
