### PR TITLE
packaging and CI refactor

### DIFF
--- a/airbrake/__about__.py
+++ b/airbrake/__about__.py
@@ -1,0 +1,27 @@
+"""Airbrake-Python package attributes and metadata."""
+
+__all__ = (
+    '__title__',
+    '__summary__',
+    '__author__',
+    '__email__',
+    '__version__',
+    '__keywords__',
+    '__license__',
+    '__url__',
+    '__notifier__',
+)
+
+__title__ = 'airbrake'
+__summary__ = 'Python SDK for airbrake.io'
+__author__ = 'BK Box, Sam Stavinoha'
+__email__ = 'samuel.stavinoha@rackspace.com'
+__version__ = '1.1.3'
+__keywords__ = ['airbrake', 'exceptions', 'airbrake.io']
+__license__ = 'Apache License, Version 2.0'
+__url__ = 'https://github.com/airbrake/airbrake-python'
+__notifier__ = {
+    'name': 'airbrake-python',
+    'version': __version__,
+    'url': __url__,
+}

--- a/airbrake/__init__.py
+++ b/airbrake/__init__.py
@@ -14,8 +14,6 @@ from airbrake import exc  # noqa
 from airbrake.notifier import Airbrake  # noqa
 from airbrake.handler import AirbrakeHandler  # noqa
 
-logging.basicConfig()
-
 
 def getLogger(name=None, **kwargs):  # pylint: disable=invalid-name
     """Return a Logger with an AirbrakeHandler."""

--- a/airbrake/__init__.py
+++ b/airbrake/__init__.py
@@ -1,25 +1,17 @@
-"""
-    airbrake-python
-    ~~~~~~~~~~~~~~~
+"""airbrake-python.
 
-    Client for sending python exceptions to airbrake.io
+Python SDK for airbrake.io
 """
 
-__version__ = "1.1.3"
-__url__ = "https://github.com/airbrake/airbrake-python"
-_notifier = {
-    'name': 'airbrake-python',
-    'version': __version__,
-    'url': __url__
-}
+# pylint: disable=wildcard-import
 
 import inspect
 import logging
 import os
 
-from airbrake import utils
-from airbrake.notifier import Airbrake
-from airbrake.handler import AirbrakeHandler
+from airbrake.__about__ import *  # noqa
+from airbrake.notifier import Airbrake  # noqa
+from airbrake.handler import AirbrakeHandler  # noqa
 
 logging.basicConfig()
 

--- a/airbrake/__init__.py
+++ b/airbrake/__init__.py
@@ -16,8 +16,8 @@ from airbrake.handler import AirbrakeHandler  # noqa
 logging.basicConfig()
 
 
-def getLogger(name=None, **kwargs):
-
+def getLogger(name=None, **kwargs):  # pylint: disable=invalid-name
+    """Return a Logger with an AirbrakeHandler."""
     if not name:
         curframe = inspect.currentframe()
         callingpath = inspect.getouterframes(curframe, 2)[1][1]
@@ -27,16 +27,17 @@ def getLogger(name=None, **kwargs):
     logger = logging.getLogger(name)
 
     if not has_airbrake_handler(logger):
-        ab = AirbrakeHandler(**kwargs)
-        logger.addHandler(ab)
+        abh = AirbrakeHandler(**kwargs)
+        logger.addHandler(abh)
         if logger.getEffectiveLevel() == logging.NOTSET:
-            logger.setLevel(ab.level)
-        elif not logger.isEnabledFor(ab.level):
-            logger.setLevel(ab.level)
+            logger.setLevel(abh.level)
+        elif not logger.isEnabledFor(abh.level):
+            logger.setLevel(abh.level)
 
     return logger
 
 
 def has_airbrake_handler(logger):
+    """Check a logger for an AirbrakeHandler."""
     return any([isinstance(handler, AirbrakeHandler)
                 for handler in logger.handlers])

--- a/airbrake/__init__.py
+++ b/airbrake/__init__.py
@@ -10,6 +10,7 @@ import logging
 import os
 
 from airbrake.__about__ import *  # noqa
+from airbrake import exc  # noqa
 from airbrake.notifier import Airbrake  # noqa
 from airbrake.handler import AirbrakeHandler  # noqa
 

--- a/airbrake/exc.py
+++ b/airbrake/exc.py
@@ -1,0 +1,11 @@
+"""Airbrake-Python custom exceptions."""
+
+
+class AirbrakeException(Exception):
+
+    """Base class for errors thrown by airbrake-python."""
+
+
+class AirbrakeNotConfigured(AirbrakeException):
+
+    """The client was not given id and key nor found in env."""

--- a/airbrake/handler.py
+++ b/airbrake/handler.py
@@ -15,16 +15,15 @@ _FAKE_LOGRECORD = logging.LogRecord('', '', '', '', '', '', '', '')
 
 
 class AirbrakeHandler(logging.Handler):
-
-    """
-    A handler class which ships logs to airbrake.io
+    """A handler class which ships logs to airbrake.io.
 
     Requires one:
         * `project_id` AND `api_key`
         * an instance of airbrake.Airbrake
     """
 
-    def __init__(self, airbrake=None, level=logging.ERROR, project_id=None, api_key=None, environment=None):
+    def __init__(self, airbrake=None, level=logging.ERROR, project_id=None,
+                 api_key=None, environment=None):
         """Initialize the Airbrake handler with a default logging level.
 
         Default level of logs handled by this class are >= ERROR,
@@ -64,7 +63,7 @@ class AirbrakeHandler(logging.Handler):
             self.airbrake.log(**airbrakeerror)
         except (KeyboardInterrupt, SystemExit):
             raise
-        except:
+        except:  # pylint: disable=bare-except
             self.handleError(record)
 
 

--- a/airbrake/handler.py
+++ b/airbrake/handler.py
@@ -9,7 +9,7 @@ to an Airbrake error should be included here.
 """
 import logging
 
-from airbrake import Airbrake
+from airbrake.notifier import Airbrake
 
 _FAKE_LOGRECORD = logging.LogRecord('', '', '', '', '', '', '', '')
 

--- a/airbrake/notifier.py
+++ b/airbrake/notifier.py
@@ -14,6 +14,7 @@ import traceback
 import requests
 
 from airbrake.__about__ import __notifier__
+from airbrake import exc as ab_exc
 from airbrake import utils
 
 
@@ -62,11 +63,13 @@ class Airbrake(object):
         self.api_key = str(api_key)
 
         if not all((self.project_id, self.api_key)):
-            raise TypeError("Airbrake API Key (api_key) and Project ID "
-                            "(project_id) must be set. These values "
-                            "may be set using the environment variables "
-                            "AIRBRAKE_API_KEY and AIRBRAKE_PROJECT_ID or "
-                            "by passing in the arguments explicitly.")
+            raise ab_exc.AirbrakeNotConfigured(
+                "Airbrake API Key (api_key) and Project ID "
+                "(project_id) must be set. These values "
+                "may be set using the environment variables "
+                "AIRBRAKE_API_KEY and AIRBRAKE_PROJECT_ID or "
+                "by passing in the arguments explicitly."
+            )
 
         self._exc_queue = utils.CheckableQueue()
 

--- a/airbrake/notifier.py
+++ b/airbrake/notifier.py
@@ -12,7 +12,7 @@ import traceback
 
 import requests
 
-from airbrake import _notifier as airbrake_python_notifier
+from airbrake.__about__ import __notifier__
 from airbrake import utils
 
 
@@ -46,7 +46,7 @@ class Airbrake(object):
         self._api_url = None
         self._context = None
         self.deploy_url = "http://api.airbrake.io/deploys.txt"
-        self.notifier = airbrake_python_notifier
+        self.notifier = __notifier__
 
         if not environment:
             environment = (os.getenv('AIRBRAKE_ENVIRONMENT') or

--- a/airbrake/notifier.py
+++ b/airbrake/notifier.py
@@ -3,6 +3,7 @@
 Initialize this class to ship errors to airbrake.io
 using the log() method.
 """
+
 import json
 import os
 import platform
@@ -41,7 +42,7 @@ class Airbrake(object):
     """
 
     def __init__(self, project_id=None, api_key=None, environment=None):
-
+        """Client constructor."""
         # properties
         self._api_url = None
         self._context = None
@@ -70,12 +71,13 @@ class Airbrake(object):
         self._exc_queue = utils.CheckableQueue()
 
     def __repr__(self):
+        """Return value for the repr function."""
         return ("Airbrake(project_id=%s, api_key=*****, environment=%s)"
                 % (self.project_id, self.environment))
 
     @property
     def context(self):
-        """Contains the python, os, and app environment context."""
+        """The python, os, and app environment context."""
         if not self._context:
             self._context = {}
             # python
@@ -120,7 +122,6 @@ class Airbrake(object):
         Exception info willl be read from sys.exc_info() if it is not
         supplied. To prevent this behavior, pass exc_info=False.
         """
-
         if not utils.is_exc_info_tuple(exc_info):
             # compatibility, allows exc_info not to be a exc tuple
             errmessage = None
@@ -202,7 +203,7 @@ class Airbrake(object):
         return response
 
 
-class Error(object):
+class Error(object):  # pylint: disable=too-few-public-methods
     """Format the exception according to airbrake.io v3 API.
 
     The airbrake.io docs used to implements this class are here:
@@ -211,7 +212,7 @@ class Error(object):
 
     def __init__(self, exc_info=None, message=None, filename=None,
                  line=None, function=None, errtype=None):
-
+        """Error object constructor."""
         self.exc_info = exc_info
 
         # default datastructure

--- a/airbrake/utils.py
+++ b/airbrake/utils.py
@@ -1,28 +1,31 @@
 """Util functions/classes for airbrake-python."""
+
 try:
     from queue import Queue, Full, Empty
 except ImportError:
-    #Py2 legacy fix
+    # Py2 legacy fix
     from Queue import Queue, Full, Empty
 
 import traceback
 import types
-import sys
 
-if sys.version_info < (3,):
-    #Py2 legacy fix
-    type_of_type = types.TypeType
-else:
-    type_of_type = type
+try:
+    TypeType = types.TypeType
+except AttributeError:
+    # For >= Python 3
+    TypeType = type
+
 
 class CheckableQueue(Queue):
 
     """Checkable FIFO Queue which makes room for new items."""
 
     def __init__(self, maxsize=1000):
+        """Queue constructor."""
         Queue.__init__(self, maxsize=maxsize)
 
     def __contains__(self, item):
+        """Check the Queue for the existence of an item."""
         try:
             with self.mutex:
                 return item in self.queue
@@ -30,6 +33,7 @@ class CheckableQueue(Queue):
             return item in self.queue
 
     def put(self, item, block=False, timeout=1):
+        """Add an item to the Queue."""
         try:
             Queue.put(self, item, block=block, timeout=timeout)
         except Full:
@@ -50,7 +54,7 @@ def is_exc_info_tuple(exc_info):
         errtype, value, tback = exc_info
         if all([x is None for x in exc_info]):
             return True
-        elif all((isinstance(errtype, type_of_type),
+        elif all((isinstance(errtype, TypeType),
                   isinstance(value, Exception),
                   isinstance(tback, types.TracebackType))):
             return True

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,14 @@
+machine:
+  python:
+    version: '2.7.10'
+
+dependencies:
+  override:
+    - pip -V
+    - pip install -U pip
+    - pip install -U tox tox-pyenv
+    - pyenv local 2.7.9 3.3.3 3.4.3 3.5.0
+
+test:
+  override:
+    - tox -v --recreate

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,20 @@
+[Messages Control]
+disable=
+  bad-builtin,
+  locally-disabled,
+  fixme,
+
+[BASIC]
+# Don't require docstrings on tests or Python Special Methods
+no-docstring-rgx=(__.*__|[tT]est.*|setUp|tearDown)
+# Some names we are okay with
+good-names=f,e,i,j,k,v,ex,_,x,y,z,kw
+# No camel case globals, max length 30
+const-rgx=(^([A-Za-z_](?!(([A-Z][a-z0-9]+)+))){2,30}$)
+max-args = 7
+max-attributes = 8
+
+[REPORTS]
+msg-template={msg_id}({symbol}): {path},{line}: {msg} | {obj}
+reports=yes
+output-format=colorized

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-requests==2.3.0
-wsgiref==0.1.2
+requests==2.8.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,45 +1,84 @@
-import re
-import ast
-from setuptools import setup, find_packages
+"""Airbrake-Python packaging and installation."""
+
+import os
+from setuptools import find_packages
+from setuptools import setup
+import subprocess
+import sys
 
 
-_version_re = re.compile(r'__version__\s+=\s+(.*)')
-_url_re = re.compile(r'__url__\s+=\s+(.*)')
+src_dir = os.path.dirname(os.path.realpath(__file__))
+about = {}
+with open(os.path.join(src_dir, 'airbrake', '__about__.py')) as abt:
+    exec(abt.read(), about)  # pylint: disable=exec-used
 
 
-with open('airbrake/__init__.py', 'rb') as f:
-    f = f.read()
-    version = str(ast.literal_eval(_version_re.search(
-        f.decode('utf-8')).group(1)))
-    url = str(ast.literal_eval(_url_re.search(
-        f.decode('utf-8')).group(1)))
+# README.rst is for PyPI page
+# pandoc --from=markdown_github --to=rst README.md --output=README.rst
+LONG_DESCRIPTION = ''
+readme_rst = os.path.join(src_dir, 'README.rst')
+if os.path.isfile(readme_rst):
+    with open(readme_rst) as rdme:
+        LONG_DESCRIPTION = rdme.read()
 
 
-dependencies = [
-    'requests>=2.2.1'
+# Add the commit hash to the keywords for sanity.
+if any(k in ' '.join(sys.argv).lower() for k in ['upload', 'dist']):
+    try:
+        current_commit = subprocess.check_output(
+            ['git', 'rev-parse', 'HEAD']).strip()
+    except (OSError, subprocess.CalledProcessError):
+        pass
+    else:
+        if current_commit and len(current_commit) == 40:
+            about['__keywords__'].append(current_commit[:8])
+
+
+CLASSIFIERS = [
+    'Intended Audience :: Developers',
+    'License :: OSI Approved :: Apache Software License',
+    'Operating System :: OS Independent',
+    'Topic :: Software Development',
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 2',
+    'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: Implementation :: CPython',
 ]
-tests_require = [
-    'mock',
-    'testfixtures'
+
+
+INSTALL_REQUIRES = [
+    'requests>=2.8.1'
 ]
 
-setup(
-    name='airbrake',
-    description='Airbrake API implementation',
-    keywords='airbrake exception',
-    version=version,
-    author="BK Box, Sam Stavinoha",
-    author_email="bk@theboxes.org",
-    url=url,
-    tests_require=tests_require,
-    test_suite='tests',
-    install_requires=dependencies,
-    packages=find_packages(exclude=['tests']),
-    classifiers=["Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4"
-    ],
-    license='Apache License (2.0)'
-)
+
+TESTS_REQUIRE = [
+    'coverage>=4.0',
+    'flake8>=2.4.1',
+    'flake8-docstrings>=0.2.1.post1',
+    'mock>=1.3.0',
+    'nose>=1.3.7',
+    'pylint>=1.4.4',
+    'testfixtures>=4.3.3',
+]
+
+
+package_attributes = {
+    'author': about['__author__'],
+    'author_email': about['__email__'],
+    'classifiers': CLASSIFIERS,
+    'description': about['__summary__'],
+    'install_requires': INSTALL_REQUIRES,
+    'keywords': ' '.join(about['__keywords__']),
+    'license': about['__license__'],
+    'long_description': LONG_DESCRIPTION,
+    'name': about['__title__'],
+    'packages': find_packages(exclude=['tests']),
+    'test_suite': 'tests',
+    'url': about['__url__'],
+    'version': about['__version__'],
+}
+
+setup(**package_attributes)

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,11 @@
 """Airbrake-Python packaging and installation."""
 
 import os
-from setuptools import find_packages
-from setuptools import setup
 import subprocess
 import sys
+
+from setuptools import find_packages
+from setuptools import setup
 
 
 src_dir = os.path.dirname(os.path.realpath(__file__))

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,7 @@
-mock==1.0.1
-nose==1.3.3
-testfixtures==4.0.1
+coverage==4.0.3
+flake8==2.5.1
+flake8-docstrings==0.2.1.post1
+mock==1.3.0
+nose==1.3.7
+pylint==1.5.1
+testfixtures==4.3.3

--- a/tests/_real_test.py
+++ b/tests/_real_test.py
@@ -1,6 +1,6 @@
-import sys
 
 import airbrake
+
 
 def find_ab_handler(logger):
     """Return the AirbrakeHandler from logger's handlers."""
@@ -10,20 +10,23 @@ def find_ab_handler(logger):
 
 
 def run_test():
+    """Run."""
     logger = airbrake.getLogger(environment='airbrake-python-test')
     abhandler = find_ab_handler(logger)
     # abhandler.airbrake.deploy()
 
     try:
-        1/0
+        1 / 0
     except ZeroDivisionError:
         logger.exception("Bad math.")
 
     try:
-        undefined
-    except Exception as err:
-        logger.exception("Undefined things!",
-            extra={'additional': 'context', 'key1': 'val1'})
+        undefined  # noqa
+    except Exception:
+        logger.exception(
+            "Undefined things!",
+            extra={'additional': 'context', 'key1': 'val1'}
+        )
 
     logger.error("No exception, but something to be concerned about.")
 

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -6,6 +6,7 @@ import mock
 from testfixtures import log_capture
 
 import airbrake
+from airbrake import exc as ab_exc
 
 BRAKE_LEVEL = 90
 logging.addLevelName(BRAKE_LEVEL, "BRAKE")
@@ -43,11 +44,17 @@ class TestAirbrakeHandlerBasic(TestAirbrake):
     def test_throws_missing_values(self):
         os.environ['AIRBRAKE_PROJECT_ID'] = ''
         os.environ['AIRBRAKE_API_KEY'] = ''
-        self.assertRaises(TypeError, airbrake.getLogger)
+        self.assertRaises(ab_exc.AirbrakeNotConfigured, airbrake.getLogger)
         self.assertRaises(
-            TypeError, airbrake.getLogger, project_id='fakeprojectid')
+            ab_exc.AirbrakeNotConfigured,
+            airbrake.getLogger,
+            project_id='fakeprojectid'
+        )
         self.assertRaises(
-            TypeError, airbrake.getLogger, api_key='fakeapikey')
+            ab_exc.AirbrakeNotConfigured,
+            airbrake.getLogger,
+            api_key='fakeapikey'
+        )
 
 
 class TestCustomLogLevel(TestAirbrake):

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,7 @@ commands=
     python -c "import sys;print('\nPYTHON VERSION\n%s\n' % sys.version)"
     nosetests {posargs} --verbose --with-doctest \
     --with-coverage --cover-html --cover-package=airbrake \
-    --cover-html-dir=coverage/ --with-xunit \
-    --ignore-files real_test
+    --cover-html-dir=coverage/ --with-xunit
 
 [testenv:style]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+envlist = py,py27,py33,py34,py35,style
+
+[testenv]
+install_command = pip install -U {opts} {packages}
+deps = -r{toxinidir}/requirements.txt
+       -r{toxinidir}/test-requirements.txt
+commands=
+    python -c "import sys;print('\nPYTHON VERSION\n%s\n' % sys.version)"
+    nosetests {posargs} --verbose --with-doctest \
+    --with-coverage --cover-html --cover-package=airbrake \
+    --cover-html-dir=coverage/ --with-xunit \
+    --ignore-files real_test
+
+[testenv:style]
+commands =
+    flake8 airbrake setup.py --statistics --exclude tests --ignore D202,D211
+    flake8 tests --statistics --ignore D100,D101,D102,D202,D211
+    pylint airbrake setup.py
+


### PR DESCRIPTION
Among other things, this change adds [a `circle.yml` file](https://github.com/airbrake/airbrake-python/pull/23/files#diff-29944324a3cbf9f4bd0162dfe3975d88) so we can start testing airbrake-python using [CircleCI](https://circleci.com) which is free for open source projects like this one.

The python versions I have configured for testing are:

- 2.7.9
- 2.7.10
- 3.3.3
- 3.4.3
- 3.5.0

I have a passing CircleCI build on my fork against the code in this pull request: https://circleci.com/gh/samstav/airbrake-python/12