### PR TITLE
Duck type traceback type

### DIFF
--- a/airbrake/utils.py
+++ b/airbrake/utils.py
@@ -70,7 +70,9 @@ def is_exc_info_tuple(exc_info):
             return True
         elif all((isinstance(errtype, TypeType),
                   isinstance(value, Exception),
-                  isinstance(tback, types.TracebackType))):
+                  hasattr(tback, 'tb_frame'),
+                  hasattr(tback, 'tb_lineno'),
+                  hasattr(tback, 'tb_next'))):
             return True
     except (TypeError, ValueError):
         pass

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -1,6 +1,4 @@
-import mock
 import sys
-import traceback
 import unittest
 
 from airbrake.notifier import format_backtrace
@@ -17,8 +15,8 @@ class FakeTraceback(object):
 class TestTraceback(unittest.TestCase):
     def _exc_info(self):
         try:
-            1/0
-        except ZeroDivisionError as e:
+            1 / 0
+        except ZeroDivisionError:
             return sys.exc_info()
 
     def _make_fake_traceback(self, tb):
@@ -27,13 +25,13 @@ class TestTraceback(unittest.TestCase):
     def test_format(self):
         tb = self._exc_info()[2]
         fake_tb = self._make_fake_traceback(tb)
-        assert format_backtrace(tb) == format_backtrace(fake_tb)
+        self.assertEqual(format_backtrace(tb), format_backtrace(fake_tb))
 
     def test_is_exc_info_tuple(self):
         exc_info = self._exc_info()
-        assert is_exc_info_tuple(exc_info)
-        exc_info = exc_info[0], exc_info[1], self._make_fake_traceback(exc_info[2])
-        assert is_exc_info_tuple(exc_info)
+        self.assertTrue(is_exc_info_tuple(exc_info))
+        fake_tb = self._make_fake_traceback(exc_info[2])
+        self.assertTrue(is_exc_info_tuple((exc_info[0], exc_info[1], fake_tb)))
 
 
 if __name__ == '__main__':

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -1,0 +1,40 @@
+import mock
+import sys
+import traceback
+import unittest
+
+from airbrake.notifier import format_backtrace
+from airbrake.utils import is_exc_info_tuple
+
+
+class FakeTraceback(object):
+    def __init__(self, tb_frame, tb_lineno, tb_next):
+        self.tb_frame = tb_frame
+        self.tb_lineno = tb_lineno
+        self.tb_next = tb_next
+
+
+class TestTraceback(unittest.TestCase):
+    def _exc_info(self):
+        try:
+            1/0
+        except ZeroDivisionError as e:
+            return sys.exc_info()
+
+    def _make_fake_traceback(self, tb):
+        return FakeTraceback(tb.tb_frame, tb.tb_lineno, tb.tb_next)
+
+    def test_format(self):
+        tb = self._exc_info()[2]
+        fake_tb = self._make_fake_traceback(tb)
+        assert format_backtrace(tb) == format_backtrace(fake_tb)
+
+    def test_is_exc_info_tuple(self):
+        exc_info = self._exc_info()
+        assert is_exc_info_tuple(exc_info)
+        exc_info = exc_info[0], exc_info[1], self._make_fake_traceback(exc_info[2])
+        assert is_exc_info_tuple(exc_info)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Easier to create fake tracebacks for custom logging. If you want to create a traceback that has a custom / modified trace, airbrake will not treat it accordingly since it does a type check against types.TracebackType. This is overly cautionary since the object is just handed off to methods in the `traceback` module which work appropriately on duck-typed object

Inspired by this stack overflow question: http://stackoverflow.com/questions/13210436/get-full-traceback