### PR TITLE
Fix `Airbrake.notify` regression

### DIFF
--- a/airbrake/notifier.py
+++ b/airbrake/notifier.py
@@ -186,14 +186,24 @@ class Airbrake(object):
                    'notifier': self.notifier,
                    'environment': environment,
                    'session': session}
-        return self.notify(json.dumps(payload, cls=utils.FailProofJSONEncoder))
+        return self.notify(payload)
 
     def notify(self, payload):
-        """Post the current errors payload body to airbrake.io."""
+        """Post the current errors payload body to airbrake.io.
+
+        :param dict payload:
+            Notification payload, in a dict/object form. The notification
+            payload will ultimately be sent as a JSON-encoded string, but here
+            it still needs to be in object form.
+        """
         headers = {'Content-Type': 'application/json'}
         api_key = {'key': self.api_key}
-        response = requests.post(self.api_url, data=payload,
-                                 headers=headers, params=api_key)
+        response = requests.post(
+            self.api_url,
+            data=json.dumps(payload, cls=utils.FailProofJSONEncoder,
+                            sort_keys=True),
+            headers=headers,
+            params=api_key)
         response.raise_for_status()
         return response
 


### PR DESCRIPTION
1d7b191a2cc3b53f76f12d09f68c857183859e08 broke the `Airbrake.notify`
interface by assuming that the `payload` argument is already encoded as
a JSON string. Unfortunately, the tests didn't catch this because the
test weren't actually exercising the `notify` method. :sad_panda:

This patch fixes the regression introduced in
https://github.com/airbrake/airbrake-python/pull/27 and adds a test to
notify to ensure that this doesn't happen again.