### PR TITLE
Upgrade to use v4 deploy endpoint

### DIFF
--- a/airbrake/notifier.py
+++ b/airbrake/notifier.py
@@ -218,17 +218,19 @@ class Airbrake(object):
     def deploy(self, env=None, username=None, repository=None,
                revision=None, version=None):
         """Reset counted errors for the airbrake project/environment."""
-        payload = {"environment":env or self.environment,
-                   "username":username,
-                   "repository":repository,
-                   "revision":revision,
-                   "version":version}
+        payload = {"environment": env or self.environment,
+                   "username": username,
+                   "repository": repository,
+                   "revision": revision,
+                   "version": version}
         headers = {'Content-Type': 'application/json'}
         api_key = {'key': self.api_key}
 
         response = requests.post(self.deploy_url,
-                                 data=json.dumps(payload, cls=utils.FailProofJSONEncoder,
-                                                 sort_keys=True),
+                                 data=json.dumps(
+                                     payload,
+                                     cls=utils.FailProofJSONEncoder,
+                                     sort_keys=True),
                                  headers=headers,
                                  params=api_key)
         response.raise_for_status()

--- a/airbrake/notifier.py
+++ b/airbrake/notifier.py
@@ -47,8 +47,8 @@ class Airbrake(object):
         """Client constructor."""
         # properties
         self._api_url = None
+        self._deploy_url = None
         self._context = None
-        self.deploy_url = "https://api.airbrake.io/deploys.txt"
         self.notifier = __notifier__
 
         if not environment:
@@ -105,11 +105,19 @@ class Airbrake(object):
 
     @property
     def api_url(self):
-        """Create the airbrake api endpoint and return a string."""
+        """Create the airbrake notice api endpoint and return a string."""
         if not self._api_url:
             self._api_url = "%s/api/v3/projects/%s/notices" % (
                 self.base_url, self.project_id)
         return self._api_url
+
+    @property
+    def deploy_url(self):
+        """Create the airbrake deploy api endpoint and return a string."""
+        if not self._deploy_url:
+            self._deploy_url = "%s/api/v4/projects/%s/deploys" % (
+                self.base_url, self.project_id)
+        return self._deploy_url
 
     def log(self, exc_info=None, message=None, filename=None,
             line=None, function=None, errtype=None, **params):
@@ -207,14 +215,22 @@ class Airbrake(object):
         response.raise_for_status()
         return response
 
-    def deploy(self, env=None):
+    def deploy(self, env=None, username=None, repository=None,
+               revision=None, version=None):
         """Reset counted errors for the airbrake project/environment."""
-        environment = env or self.environment
+        payload = {"environment":env or self.environment,
+                   "username":username,
+                   "repository":repository,
+                   "revision":revision,
+                   "version":version}
+        headers = {'Content-Type': 'application/json'}
+        api_key = {'key': self.api_key}
 
-        params = {'api_key': self.api_key,
-                  'deploy[rails_env]': str(environment)}
-
-        response = requests.post(self.deploy_url, params=params)
+        response = requests.post(self.deploy_url,
+                                 data=json.dumps(payload, cls=utils.FailProofJSONEncoder,
+                                                 sort_keys=True),
+                                 headers=headers,
+                                 params=api_key)
         response.raise_for_status()
         return response
 

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -83,6 +83,23 @@ class TestAirbrakeNotifier(unittest.TestCase):
             )
             self.assertEqual(expected_call_args, requests_post.call_args)
 
+    def test_deploy_payload(self):
+        with mock.patch('requests.post') as requests_post:
+            ab = Airbrake(project_id=1234, api_key='fake', environment='test')
+            ab.deploy('test',
+                      'user1',
+                      'https://github.com/airbrake/airbrake',
+                      '38748467ea579e7ae64f7815452307c9d05e05c5',
+                      'v2.0')
+
+            expected_call_args = mock.call(
+                'https://airbrake.io/api/v4/projects/1234/deploys',
+                data='{"environment": "test", "repository": "https://github.com/airbrake/airbrake", "revision": "38748467ea579e7ae64f7815452307c9d05e05c5", "username": "user1", "version": "v2.0"}',
+                headers={'Content-Type': 'application/json'},
+                params={'key': 'fake'}
+            )
+            self.assertEqual(expected_call_args, requests_post.call_args)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -94,7 +94,11 @@ class TestAirbrakeNotifier(unittest.TestCase):
 
             expected_call_args = mock.call(
                 'https://airbrake.io/api/v4/projects/1234/deploys',
-                data='{"environment": "test", "repository": "https://github.com/airbrake/airbrake", "revision": "38748467ea579e7ae64f7815452307c9d05e05c5", "username": "user1", "version": "v2.0"}',
+                data='{"environment": "test",'
+                     ' "repository": "https://github.com/airbrake/airbrake",'
+                     ' "revision": "38748467ea579e7ae64f7815452307c9d05e05c5",'
+                     ' "username": "user1",'
+                     ' "version": "v2.0"}',
                 headers={'Content-Type': 'application/json'},
                 params={'key': 'fake'}
             )


### PR DESCRIPTION
Closes: https://github.com/airbrake/airbrake-python/issues/38

We were using an older endpoint, this moves us up to the latest, v4 one.