### PR TITLE
Add hostname to context and allow env override

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ _by default, the `AirbrakeHandler` only handles logs level ERROR (40) and above_
 #### Additional Options
 More options are available to configure this library. Similar to setup, you can do this with environment variables
 ```
-export AIRBRAKE_HOSTNAME=sassbox-101.prod.api
+export HOSTNAME=sassbox-101.prod.api
 ```
 Or when you instantiate the logger
 ```python

--- a/README.md
+++ b/README.md
@@ -77,6 +77,21 @@ yourlogger.addHandler(airbrake.AirbrakeHandler())
 ```
 _by default, the `AirbrakeHandler` only handles logs level ERROR (40) and above_
 
+#### Additional Options
+More options are available to configure this library. Similar to setup, you can do this with environment variables
+```
+export AIRBRAKE_HOSTNAME=sassbox-101.prod.api
+```
+Or when you instantiate the logger
+```python
+import airbrake
+
+logger = airbrake.getLogger(api_key=*****, project_id=12345, hostname='sassbox-101.prod.api')
+```
+
+The available options are:
+- hostname (AIRBRAKE_HOSTNAME), default: `socket.gethostname()`
+
 ####giving your exceptions more context
 ```python
 import airbrake

--- a/airbrake/handler.py
+++ b/airbrake/handler.py
@@ -23,7 +23,7 @@ class AirbrakeHandler(logging.Handler):
     """
 
     def __init__(self, airbrake=None, level=logging.ERROR, project_id=None,
-                 api_key=None, environment=None, base_url=None):
+                 api_key=None, environment=None, base_url=None, hostname=None):
         """Initialize the Airbrake handler with a default logging level.
 
         Default level of logs handled by this class are >= ERROR,
@@ -37,7 +37,7 @@ class AirbrakeHandler(logging.Handler):
             self.airbrake = airbrake
         else:
             self.airbrake = Airbrake(project_id, api_key, environment,
-                                     base_url)
+                                     base_url, hostname)
 
     def emit(self, record):
         """Log the record airbrake.io style.

--- a/airbrake/handler.py
+++ b/airbrake/handler.py
@@ -22,6 +22,8 @@ class AirbrakeHandler(logging.Handler):
         * an instance of airbrake.Airbrake
     """
 
+    # pylint: disable=too-many-arguments
+
     def __init__(self, airbrake=None, level=logging.ERROR, project_id=None,
                  api_key=None, environment=None, base_url=None, hostname=None):
         """Initialize the Airbrake handler with a default logging level.

--- a/airbrake/notifier.py
+++ b/airbrake/notifier.py
@@ -43,7 +43,7 @@ class Airbrake(object):
     """
 
     def __init__(self, project_id=None, api_key=None, environment=None,
-                 base_url=None):
+                 base_url=None, hostname=None):
         """Client constructor."""
         # properties
         self._api_url = None
@@ -54,6 +54,10 @@ class Airbrake(object):
         if not environment:
             environment = (os.getenv('AIRBRAKE_ENVIRONMENT') or
                            socket.gethostname())
+        if not hostname:
+            hostname = (os.getenv('AIRBRAKE_HOSTNAME') or
+                        socket.gethostname())
+
         if not project_id:
             project_id = os.getenv('AIRBRAKE_PROJECT_ID', '')
         if not api_key:
@@ -66,6 +70,7 @@ class Airbrake(object):
         self.project_id = str(project_id)
         self.api_key = str(api_key)
         self.base_url = str(base_url)
+        self.hostname = str(hostname)
 
         if not all((self.project_id, self.api_key)):
             raise ab_exc.AirbrakeNotConfigured(
@@ -96,6 +101,8 @@ class Airbrake(object):
             self._context.update({'os': plat})
             # env name
             self._context.update({'environment': self.environment})
+            self._context.update({'hostname': self.hostname})
+
             # TODO(samstav)
             #   add user info:
             #       userID, userName, userEmail

--- a/airbrake/notifier.py
+++ b/airbrake/notifier.py
@@ -42,6 +42,8 @@ class Airbrake(object):
         http://help.airbrake.io/kb/api-2/notifier-api-v3
     """
 
+    # pylint: disable=too-many-instance-attributes
+
     def __init__(self, project_id=None, api_key=None, environment=None,
                  base_url=None, hostname=None):
         """Client constructor."""

--- a/airbrake/notifier.py
+++ b/airbrake/notifier.py
@@ -57,7 +57,7 @@ class Airbrake(object):
             environment = (os.getenv('AIRBRAKE_ENVIRONMENT') or
                            socket.gethostname())
         if not hostname:
-            hostname = (os.getenv('AIRBRAKE_HOSTNAME') or
+            hostname = (os.getenv('HOSTNAME') or
                         socket.gethostname())
 
         if not project_id:


### PR DESCRIPTION
Closes: https://github.com/airbrake/airbrake-python/issues/35

Hostname is not getting sent with notices. This will add it.