### PR TITLE
Feature/add separate notice obj

### DIFF
--- a/airbrake/notice.py
+++ b/airbrake/notice.py
@@ -1,0 +1,103 @@
+"""Airbrake Notice module.
+
+Wrapper classes for converting various types of data into Airbrake formatted
+errors
+"""
+
+import traceback
+from airbrake import utils
+
+
+class Notice(object):  # pylint: disable=too-few-public-methods
+    """Create Airbrake formatted notice objects from a variety of objects."""
+
+    def __init__(self, exception, params=None, session=None,
+                 environment=None, context=None, notifier=None):
+        """Client Constructor."""
+
+        self.exception = exception
+        self.params = params
+        self.session = session
+        self.environment = environment
+        self.context = context
+        self.notifier = notifier
+
+        if isinstance(exception, str):
+            error = {
+                'type': "Error",
+                'backtrace': [{'file': "N/A",
+                               'line': 1,
+                               'function': "N/A"}],
+                'message': exception}
+            self.errors = [error]
+
+        if isinstance(exception, Exception) or \
+                isinstance(exception, BaseException):
+            error = {
+                'type': type(exception).__name__,
+                'backtrace': [{'file': "N/A",
+                               'line': 1,
+                               'function': "N/A"}],
+                'message': str(exception)}
+            self.errors = [error]
+
+        if isinstance(exception, Error):
+            self.errors = [exception.data]
+
+    @property
+    def payload(self):
+        """Create a dict of all non-empty data in this notice."""
+        return utils.non_empty_keys({'context': self.context,
+                                     'params': self.params,
+                                     'errors': self.errors,
+                                     'notifier': self.notifier,
+                                     'environment': self.environment,
+                                     'session': self.session})
+
+
+class Error(object):  # pylint: disable=too-few-public-methods
+    """Format the exception according to airbrake.io v3 API.
+
+    The airbrake.io docs used to implements this class are here:
+        http://help.airbrake.io/kb/api-2/notifier-api-v3
+    """
+
+    def __init__(self, exc_info=None, message=None, filename=None,
+                 line=None, function=None, errtype=None):
+        """Error object constructor."""
+        self.exc_info = exc_info
+
+        # default datastructure
+        self.data = {
+            'type': errtype or "Record",
+            'backtrace': [{'file': filename or "N/A",
+                           'line': line or 1,
+                           'function': function or "N/A"}],
+            'message': message or "N/A"}
+
+        if utils.is_exc_info_tuple(self.exc_info):
+            if not all(self.exc_info):
+                return
+            tbmessage = utils.pytb_lastline(self.exc_info)
+            self.data.update(
+                {'type': self.exc_info[1].__class__.__name__,
+                 'backtrace': format_backtrace(self.exc_info[2]),
+                 'message': message or tbmessage})
+        else:
+            raise TypeError(
+                "Airbrake module (notice.Error) received "
+                "unsupported 'exc_info' type. Should be a "
+                "3-piece tuple as returned by sys.exc_info(). "
+                "Invalid argument was %s"
+                % self.exc_info)
+
+
+def format_backtrace(trace):
+    """Create a formatted dictionary from a traceback object."""
+    backtrace = []
+    for filename, line, func, _ in traceback.extract_tb(trace):
+        desc = {'file': filename,
+                'line': line,
+                'function': func}
+        backtrace.append(desc)
+    return backtrace

--- a/airbrake/notifier.py
+++ b/airbrake/notifier.py
@@ -223,6 +223,7 @@ class Airbrake(object):
         """
 
         notice = exception
+        payload = None
 
         if isinstance(exception, Notice):
             payload = notice.payload

--- a/airbrake/notifier.py
+++ b/airbrake/notifier.py
@@ -9,13 +9,13 @@ import os
 import platform
 import socket
 import sys
-import traceback
 
 import requests
 
 from airbrake.__about__ import __notifier__
 from airbrake import exc as ab_exc
 from airbrake import utils
+from airbrake.notice import Notice, Error
 
 
 class Airbrake(object):
@@ -195,22 +195,45 @@ class Airbrake(object):
             line=line, function=function, errtype=errtype)
         environment = params.pop('environment', {})
         session = params.pop('session', {})
-        payload = {'context': self.context,
-                   'params': params,
-                   'errors': [error.data],
-                   'notifier': self.notifier,
-                   'environment': environment,
-                   'session': session}
-        return self.notify(payload)
+        notice = self.build_notice(error, params, session, environment)
 
-    def notify(self, payload):
+        return self.notify(notice)
+
+    def build_notice(self, exception, params=None, session=None,
+                     environment=None):
+        """Build a notice object.
+
+        :param Error|Exception|str exception:
+        :param params:
+        :param session:
+        :param environment:
+        :return: Notice
+        """
+
+        return Notice(exception, params, session, environment, self.context,
+                      self.notifier)
+
+    def notify(self, exception):
         """Post the current errors payload body to airbrake.io.
 
-        :param dict payload:
-            Notification payload, in a dict/object form. The notification
-            payload will ultimately be sent as a JSON-encoded string, but here
-            it still needs to be in object form.
+        :param Exception|str|Notice exception:
+            Notice object, string, or Exception object.
+            The notification payload will ultimately be sent as a JSON-encoded
+            string.
         """
+
+        notice = exception
+
+        if isinstance(exception, Notice):
+            payload = notice.payload
+
+        if isinstance(exception, str) or \
+                isinstance(exception, Exception) or \
+                isinstance(exception, BaseException) or \
+                isinstance(exception, Error):
+            notice = self.build_notice(exception)
+            payload = notice.payload
+
         headers = {'Content-Type': 'application/json'}
         api_key = {'key': self.api_key}
         response = requests.post(
@@ -249,51 +272,3 @@ class Airbrake(object):
                                  timeout=self.timeout)
         response.raise_for_status()
         return response
-
-
-class Error(object):  # pylint: disable=too-few-public-methods
-    """Format the exception according to airbrake.io v3 API.
-
-    The airbrake.io docs used to implements this class are here:
-        http://help.airbrake.io/kb/api-2/notifier-api-v3
-    """
-
-    def __init__(self, exc_info=None, message=None, filename=None,
-                 line=None, function=None, errtype=None):
-        """Error object constructor."""
-        self.exc_info = exc_info
-
-        # default datastructure
-        self.data = {
-            'type': errtype or "Record",
-            'backtrace': [{'file': filename or "N/A",
-                           'line': line or 1,
-                           'function': function or "N/A"}],
-            'message': message or "N/A"}
-
-        if utils.is_exc_info_tuple(self.exc_info):
-            if not all(self.exc_info):
-                return
-            tbmessage = utils.pytb_lastline(self.exc_info)
-            self.data.update(
-                {'type': self.exc_info[1].__class__.__name__,
-                 'backtrace': format_backtrace(self.exc_info[2]),
-                 'message': message or tbmessage})
-        else:
-            raise TypeError(
-                "Airbrake module (notifier.Error) received "
-                "unsupported 'exc_info' type. Should be a "
-                "3-piece tuple as returned by sys.exc_info(). "
-                "Invalid argument was %s"
-                % self.exc_info)
-
-
-def format_backtrace(trace):
-    """Create a formatted dictionary from a traceback object."""
-    backtrace = []
-    for filename, line, func, _ in traceback.extract_tb(trace):
-        desc = {'file': filename,
-                'line': line,
-                'function': func}
-        backtrace.append(desc)
-    return backtrace

--- a/airbrake/utils.py
+++ b/airbrake/utils.py
@@ -121,3 +121,20 @@ def pytb_lastline(excinfo=None):
     lines = [line for line in lines if str(line).lower() != 'none']
     if lines:
         return lines[-1]
+
+
+def non_empty_keys(data):
+    """Strip out empty keys from a dict.
+
+    :param dict data: the dict to copy
+    :return:
+    """
+    non_empty = {}
+    for (key, val) in data.items():
+        if isinstance(val, dict):
+            data = non_empty_keys(val)
+            if data:
+                non_empty[key] = data
+        elif val and val != 'None':
+            non_empty[key] = val
+    return non_empty

--- a/tests/test_notice.py
+++ b/tests/test_notice.py
@@ -1,0 +1,65 @@
+import unittest
+import sys
+
+from airbrake.notice import Notice, Error, format_backtrace
+from airbrake.utils import pytb_lastline
+
+
+class TestNotice(unittest.TestCase):
+    def setUp(self):
+        super(TestNotice, self).setUp()
+
+    def test_create_notice_str(self):
+        exception_str = "This is a test"
+        exception_type = 'Error'
+        notice = Notice(exception_str)
+
+        expected_payload = {
+            'errors': [{'backtrace': [{'function': 'N/A',
+                                       'line': 1,
+                                       'file': 'N/A'}],
+                        'message': exception_str,
+                        'type': exception_type}],
+        }
+        self.assertEqual(expected_payload, notice.payload)
+
+    def test_create_notice_exception(self):
+        exception_str = "This is a test"
+        exception = ValueError(exception_str)
+        exception_type = type(exception).__name__
+        notice = Notice(exception)
+
+        expected_payload = {
+            'errors': [{'backtrace': [{'function': 'N/A',
+                                       'line': 1,
+                                       'file': 'N/A'}],
+                        'message': exception_str,
+                        'type': exception_type}],
+        }
+        self.assertEqual(expected_payload, notice.payload)
+
+    def test_create_notice_error(self):
+        try:
+            raise TypeError
+        except:
+            exc_info = sys.exc_info()
+            error = Error(exc_info=exc_info)
+            notice = Notice(error)
+
+            data = {
+                'type': exc_info[1].__class__.__name__,
+                'backtrace': format_backtrace(exc_info[2]),
+                'message': pytb_lastline(exc_info)
+            }
+
+            expected_payload = {
+                'errors': [data]
+            }
+
+            self.assertEqual(expected_payload, notice.payload)
+
+    def test_payload_no_empty_keys(self):
+        exception = Exception("This is a test")
+        notice = Notice(exception, session=None)
+
+        self.assertTrue("session" not in notice.payload)

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -86,24 +86,6 @@ class TestAirbrakeNotifier(unittest.TestCase):
             extra = {'very': 'important', 'jsonify': non_serializable}
             self.logger.exception(Exception(msg), extra=extra)
 
-    def test_notify_payload(self):
-        # 1d7b191a2cc3b53f76f12d09f68c857183859e08 broke the `notify interface
-        # by making the assumption that the payload sent to `notify` is already
-        # encoded as a JSON string.
-        # This test ensures that such a regression can't happen again.
-        with mock.patch('requests.post') as requests_post:
-            ab = Airbrake(project_id=1234, api_key='fake', environment='test')
-            payload = dict(foo=1, bar=2)
-            ab.notify(payload)
-
-            expected_call_args = mock.call(
-                'https://airbrake.io/api/v3/projects/1234/notices',
-                data='{"bar": 2, "foo": 1}',
-                headers={'Content-Type': 'application/json'},
-                params={'key': 'fake'}
-            )
-            self.assertEqual(expected_call_args, requests_post.call_args)
-
     def test_notify_context(self):
         with mock.patch('requests.post') as requests_post:
             version = platform.python_version()

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -1,7 +1,7 @@
 import sys
 import unittest
 
-from airbrake.notifier import format_backtrace
+from airbrake.notice import format_backtrace
 from airbrake.utils import is_exc_info_tuple
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,27 @@
+import unittest
+
+import airbrake.utils
+
+
+class TestUtils(unittest.TestCase):
+    def test_non_empty_keys(self):
+        data = {
+            'remove_me': None,
+            'remove_me_too': 'None',
+            'remove_me_nested': {'remove_me': None,
+                                 'remove_me_too': 'None'},
+            'valid': 'testing',
+            'valid_nested': {'valid_nested': 'testing'},
+            'valid_nested_mix': {'remove_me': None,
+                                 'remove_me_too': 'None',
+                                 'valid_nested': 'testing'}
+        }
+        expected_data = {
+            'valid': 'testing',
+            'valid_nested': {'valid_nested': 'testing'},
+            'valid_nested_mix': {'valid_nested': 'testing'}
+        }
+
+        clean_data = airbrake.utils.non_empty_keys(data)
+
+        self.assertEqual(expected_data, clean_data)


### PR DESCRIPTION
This sets us up a bit more nicely for a bunch of other features.

`build_notice()` would be a good home for filters https://github.com/airbrake/airbrake-python/issues/48 and user data: https://github.com/airbrake/airbrake-python/issues/60.
Shifting to using a `Notice` class that takes `Exception` and `Error` objects also makes it easier for integrations to use this library, as we don't need to finagle those objects into a payload object for `notify()`.