### PR TITLE
Accept unicode error messages.

### DIFF
--- a/airbrake/notifier.py
+++ b/airbrake/notifier.py
@@ -329,16 +329,9 @@ class Airbrake(object):
             The notification payload will ultimately be sent as a JSON-encoded
             string.
         """
-
-        notice = exception
-        payload = None
-
-        if isinstance(exception, Notice):
-            payload = notice.payload
-
-        if isinstance(exception, (BaseException, Error, Exception, str)):
-            notice = self.build_notice(exception)
-            payload = notice.payload
+        ex = exception
+        notice = ex if isinstance(ex, Notice) else self.build_notice(ex)
+        payload = notice.payload
 
         payload = self.apply_filters(payload)
 

--- a/tests/test_notice.py
+++ b/tests/test_notice.py
@@ -24,6 +24,21 @@ class TestNotice(unittest.TestCase):
         }
         self.assertEqual(expected_payload, notice.payload)
 
+    def test_create_notice_unicode(self):
+        exception_str = u"This is a test"
+        exception_type = 'Error'
+        notice = Notice(exception_str)
+
+        expected_payload = {
+            'errors': [{'backtrace': [{'function': 'N/A',
+                                       'line': 1,
+                                       'file': 'N/A'}],
+                        'message': exception_str,
+                        'type': exception_type,
+                        'severity': ErrorLevels.DEFAULT_LEVEL}],
+        }
+        self.assertEqual(expected_payload, notice.payload)
+
     def test_create_notice_exception(self):
         exception_str = "This is a test"
         exception = ValueError(exception_str)


### PR DESCRIPTION
The current code will not properly load a unicode string into an error object, and results in a error when building the payload.