### PR TITLE
Move 'severity' field from errors[] to context

### DIFF
--- a/airbrake/notice.py
+++ b/airbrake/notice.py
@@ -38,12 +38,12 @@ class Notice(object):  # pylint: disable=too-few-public-methods
         self.params = params
         self.session = session
         self.environment = environment
-        self.context = context
+        self.context = context or {}
+
+        self.context['severity'] = severity or ErrorLevels.DEFAULT_LEVEL
 
         if user:
             data = _trim_data(user, ['id', 'name', 'email'])
-            if not context:
-                self.context = {}
             self.context['user'] = data
 
         self.notifier = notifier
@@ -66,8 +66,7 @@ class Notice(object):  # pylint: disable=too-few-public-methods
                 'backtrace': [{'file': 'N/A',
                                'line': 1,
                                'function': 'N/A'}],
-                'message': str(exception),
-                'severity': severity or ErrorLevels.DEFAULT_LEVEL}
+                'message': str(exception)}
 
             if isinstance(exception, (BaseException, Exception)):
                 error['type'] = type(exception).__name__
@@ -103,8 +102,7 @@ class Error(object):  # pylint: disable=too-few-public-methods
     # pylint: disable=too-many-arguments
 
     def __init__(self, exc_info=None, message=None, filename=None,
-                 line=None, function=None, errtype=None,
-                 severity=None):
+                 line=None, function=None, errtype=None):
         """Error object constructor."""
         self.exc_info = exc_info
 
@@ -114,8 +112,7 @@ class Error(object):  # pylint: disable=too-few-public-methods
             'backtrace': [{'file': filename or "N/A",
                            'line': line or 1,
                            'function': function or "N/A"}],
-            'message': message or "N/A",
-            'severity': severity or ErrorLevels.DEFAULT_LEVEL}
+            'message': message or "N/A"}
 
         if utils.is_exc_info_tuple(self.exc_info):
             if not all(self.exc_info):
@@ -124,8 +121,7 @@ class Error(object):  # pylint: disable=too-few-public-methods
             self.data.update(
                 {'type': self.exc_info[1].__class__.__name__,
                  'backtrace': format_backtrace(self.exc_info[2]),
-                 'message': message or tbmessage,
-                 'severity': severity or ErrorLevels.DEFAULT_LEVEL})
+                 'message': message or tbmessage})
         else:
             raise TypeError(
                 "Airbrake module (notice.Error) received "

--- a/airbrake/notifier.py
+++ b/airbrake/notifier.py
@@ -243,10 +243,11 @@ class Airbrake(object):
         severity = params.get("severity", None)
         error = Error(
             exc_info=exc_info, message=message, filename=filename,
-            line=line, function=function, errtype=errtype, severity=severity)
+            line=line, function=function, errtype=errtype)
         environment = params.pop('environment', {})
         session = params.pop('session', {})
-        notice = self.build_notice(error, params, session, environment)
+        notice = self.build_notice(error, params, session, environment,
+                                   severity=severity)
         return self.notify(notice)
 
     def capture(self, exc_info=None, message=None, filename=None,

--- a/tests/test_notice.py
+++ b/tests/test_notice.py
@@ -19,8 +19,8 @@ class TestNotice(unittest.TestCase):
                                        'line': 1,
                                        'file': 'N/A'}],
                         'message': exception_str,
-                        'type': exception_type,
-                        'severity': ErrorLevels.DEFAULT_LEVEL}],
+                        'type': exception_type}],
+            'context': {'severity': ErrorLevels.DEFAULT_LEVEL},
         }
         self.assertEqual(expected_payload, notice.payload)
 
@@ -34,8 +34,8 @@ class TestNotice(unittest.TestCase):
                                        'line': 1,
                                        'file': 'N/A'}],
                         'message': exception_str,
-                        'type': exception_type,
-                        'severity': ErrorLevels.DEFAULT_LEVEL}],
+                        'type': exception_type}],
+            'context': {'severity': ErrorLevels.DEFAULT_LEVEL},
         }
         self.assertEqual(expected_payload, notice.payload)
 
@@ -59,9 +59,9 @@ class TestNotice(unittest.TestCase):
                                        'line': 1,
                                        'file': 'N/A'}],
                         'message': exception_str,
-                        'type': exception_type,
-                        'severity': ErrorLevels.DEFAULT_LEVEL}],
-            "context": {'user': user}
+                        'type': exception_type}],
+            "context": {'user': user,
+                        'severity': ErrorLevels.DEFAULT_LEVEL}
         }
         self.assertEqual(expected_payload, notice.payload)
 
@@ -70,18 +70,18 @@ class TestNotice(unittest.TestCase):
             raise TypeError
         except:
             exc_info = sys.exc_info()
-            error = Error(exc_info=exc_info, severity=ErrorLevels.WARNING)
+            error = Error(exc_info=exc_info)
             notice = Notice(error)
 
             data = {
                 'type': exc_info[1].__class__.__name__,
                 'backtrace': format_backtrace(exc_info[2]),
-                'message': pytb_lastline(exc_info),
-                'severity': ErrorLevels.WARNING
+                'message': pytb_lastline(exc_info)
             }
 
             expected_payload = {
-                'errors': [data]
+                'errors': [data],
+                'context': {'severity': ErrorLevels.DEFAULT_LEVEL},
             }
 
             self.assertEqual(expected_payload, notice.payload)


### PR DESCRIPTION
Hello, thank you for the great work.

When I tried to use `severity` option, it didn't work.
It seems that the [API](https://airbrake.io/docs/api/#create-notice-v3) requires `severity` field placed in `context` field while this library places it in each `errors[i]` field.

This PR fixes that.
Please check it.

Thank you.