### PR TITLE
Silence the stderr git warning when running from a non-git directory

### DIFF
--- a/airbrake/utils.py
+++ b/airbrake/utils.py
@@ -25,7 +25,6 @@ except ImportError:
     DEVNULL = open(os.devnull, 'wb')
 
 
-
 class FailProofJSONEncoder(json.JSONEncoder):
     """Uses object's representation for unsupported types."""
 

--- a/airbrake/utils.py
+++ b/airbrake/utils.py
@@ -18,6 +18,13 @@ except AttributeError:
     # For >= Python 3
     TypeType = type
 
+try:
+    # For >= Python 3
+    from subprocess import DEVNULL
+except ImportError:
+    DEVNULL = open(os.devnull, 'wb')
+
+
 
 class FailProofJSONEncoder(json.JSONEncoder):
     """Uses object's representation for unsupported types."""
@@ -156,7 +163,7 @@ def _git_revision_with_binary():
     """Get the latest git hash using the git binary."""
     try:
         rev = subprocess.check_output(["git", "rev-parse", "HEAD"],
-                                      stderr=subprocess.STDOUT)
+                                      stderr=DEVNULL)
         return str(rev.strip())
     except (OSError, subprocess.CalledProcessError):
         return None

--- a/airbrake/utils.py
+++ b/airbrake/utils.py
@@ -166,7 +166,10 @@ def _git_revision_from_file():
     """Get the latest git hash from file in .git/refs/heads/master."""
     path = _get_git_path()
     if os.path.exists(path):
-        return str(_get_git_ref_revision(path))
+        rev = _get_git_ref_revision(path)
+        if rev is None:
+            return None
+        return str(rev)
 
 
 def _get_git_ref_revision(path):

--- a/airbrake/utils.py
+++ b/airbrake/utils.py
@@ -155,7 +155,8 @@ def get_local_git_revision():
 def _git_revision_with_binary():
     """Get the latest git hash using the git binary."""
     try:
-        rev = subprocess.check_output(["git", "rev-parse", "HEAD"])
+        rev = subprocess.check_output(["git", "rev-parse", "HEAD"],
+                                      stderr=subprocess.STDOUT)
         return str(rev.strip())
     except (OSError, subprocess.CalledProcessError):
         return None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,7 @@ import mock
 
 import airbrake.utils
 
-IS_CIRCLE_CI = 'CIRCLE_SHA1' in os.environ
+IS_CIRCLE_CI = 'CIRCLECI' in os.environ
 
 
 class TestUtils(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@ import os
 import unittest
 import subprocess
 import tempfile
+import mock
 
 import airbrake.utils
 
@@ -69,3 +70,10 @@ class TestUtils(unittest.TestCase):
         finally:
             # Go back to where we started
             os.chdir(start_dir)
+
+    def test_git_revision_from_file_non_git(self):
+        non_git_dir = tempfile.gettempdir()
+        with mock.patch('airbrake.utils._get_git_path') as meth:
+            meth.return_value = non_git_dir
+            rev = airbrake.utils._git_revision_from_file()
+            self.assertIsNone(rev)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 import subprocess
+import tempfile
 
 import airbrake.utils
 
@@ -51,3 +52,20 @@ class TestUtils(unittest.TestCase):
 
         if has_fs_access and rev:
             self.assertTrue(rev_file, rev_binary)
+
+    def test_get_git_ref_revision_non_git(self):
+        non_git_dir = tempfile.gettempdir()
+        rev = airbrake.utils._get_git_ref_revision(os.path.join(non_git_dir, '.git'))
+        self.assertIsNone(rev)
+
+    def test_git_revision_with_binary_non_git(self):
+        non_git_dir = tempfile.gettempdir()
+        start_dir = os.getcwd()
+        try:
+            # Move to a non-git directory
+            os.chdir(non_git_dir)
+            rev = airbrake.utils._git_revision_with_binary()
+            self.assertIsNone(rev)
+        finally:
+            # Go back to where we started
+            os.chdir(start_dir)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,8 @@ import mock
 
 import airbrake.utils
 
+IS_CIRCLE_CI = 'CIRCLE_SHA1' in os.environ
+
 
 class TestUtils(unittest.TestCase):
     def test_non_empty_keys(self):
@@ -44,10 +46,13 @@ class TestUtils(unittest.TestCase):
 
         if has_fs_access:
             rev_file = airbrake.utils._git_revision_from_file()
-            self.assertIsNotNone(rev_file,
-                                 'No revision in %s: %s' % (
-                                     head_ref_path_file,
-                                     ref_path))
+            if not IS_CIRCLE_CI:
+                # CircleCI does not have anything in .git/refs/heads/pull
+                # so this is not valid.
+                self.assertIsNotNone(rev_file,
+                                     'No revision in %s: %s' % (
+                                         head_ref_path_file,
+                                         ref_path))
 
         rev = subprocess.check_output(["git", "rev-parse", "HEAD"])
         if rev:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -32,6 +32,8 @@ class TestUtils(unittest.TestCase):
 
         self.assertEqual(expected_data, clean_data)
 
+    @unittest.skipIf(IS_CIRCLE_CI,
+                     "Pull requests in CirlceCI don't work correctly")
     def test_get_local_git_revision(self):
         rev = airbrake.utils.get_local_git_revision()
         self.assertIsNotNone(rev)
@@ -46,13 +48,10 @@ class TestUtils(unittest.TestCase):
 
         if has_fs_access:
             rev_file = airbrake.utils._git_revision_from_file()
-            if not IS_CIRCLE_CI:
-                # CircleCI does not have anything in .git/refs/heads/pull
-                # so this is not valid.
-                self.assertIsNotNone(rev_file,
-                                     'No revision in %s: %s' % (
-                                         head_ref_path_file,
-                                         ref_path))
+            self.assertIsNotNone(rev_file,
+                                 'No revision in %s: %s' % (
+                                     head_ref_path_file,
+                                     ref_path))
 
         rev = subprocess.check_output(["git", "rev-parse", "HEAD"])
         if rev:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -56,7 +56,8 @@ class TestUtils(unittest.TestCase):
 
     def test_get_git_ref_revision_non_git(self):
         non_git_dir = tempfile.gettempdir()
-        rev = airbrake.utils._get_git_ref_revision(os.path.join(non_git_dir, '.git'))
+        rev = airbrake.utils._get_git_ref_revision(
+            os.path.join(non_git_dir, '.git'))
         self.assertIsNone(rev)
 
     def test_git_revision_with_binary_non_git(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,7 +44,10 @@ class TestUtils(unittest.TestCase):
 
         if has_fs_access:
             rev_file = airbrake.utils._git_revision_from_file()
-            self.assertIsNotNone(rev_file)
+            self.assertIsNotNone(rev_file,
+                                 'No revision in %s: %s' % (
+                                     head_ref_path_file,
+                                     ref_path))
 
         rev = subprocess.check_output(["git", "rev-parse", "HEAD"])
         if rev:

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py,py27,py33,py34,py35,style
 
 [testenv]
+passenv = CIRCLECI
 install_command = pip install -U {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
@@ -16,4 +17,3 @@ commands =
     flake8 airbrake setup.py --statistics --exclude tests --ignore D202,D211
     flake8 tests --statistics --ignore D100,D101,D102,D202,D211
     pylint airbrake setup.py
-


### PR DESCRIPTION
When running from a non-git directory the process will print `fatal: Not a git repository (or any of the parent directories): .git` to stderr once every minute or so. In our case we use a carefully packaged Docker container which excludes the git directory to keep the sizes smaller. This pull request silences that warning and maintains the same functionality (returning `None`)

A test was also added to reproduce the issue while troubleshooting, though it was unable to capture the existing subprocess stderr so could not assert there will not be a regression. The new test will, however, display the `fatal: Not a git repository (or any of the parent directories): .git` warning when running test tests if there is a regression in the future.