### PR TITLE
Send uncaught exceptions by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ except Exception:
     logger.exception("Bad math.")
 ```
 
+By default, airbrake will catch and send uncaught exceptions. To avoid this behvaiour, use the send_uncaught_exc option:
+`logger = airbrake.getLogger(api_key=*****, project_id=12345, send_uncaught_exc=False)`
+
 ### setup for Airbrake On-Premise and other compatible back-ends (e.g. Errbit)
 
 Airbrake [Enterprise](https://airbrake.io/enterprise) and self-hosted alternatives, such as [Errbit](https://github.com/errbit/errbit), provide a compatible API.
@@ -97,6 +100,7 @@ The available options are:
 - host, defaults to env var `AIRBRAKE_HOST` or https://airbrake.io
 - root_directory, defaults to None
 - timeout, defaults to 5. (Number of seconds before each request times out)
+- send_uncaught_exc, defaults to True (Whether or not to send uncaught exceptions)
 
 #### giving your exceptions more context
 ```python

--- a/airbrake/notifier.py
+++ b/airbrake/notifier.py
@@ -181,10 +181,10 @@ class Airbrake(object):
                 self.host, self.project_id)
         return self._deploy_url
 
-    def uncaught_handler(self, ex_cls, ex, tb):
-        exc_info = (ex_cls, ex, tb)
+    def uncaught_handler(self, exception_class, exception, trace):
+        """Catch uncaught exceptions and send to airbrake."""
+        exc_info = (exception_class, exception, trace)
         error = Error(exc_info=exc_info)
-        notice = self.build_notice(error)
         self.notify(error)
         self.log(error)
         self.excepthook(exc_info)

--- a/airbrake/notifier.py
+++ b/airbrake/notifier.py
@@ -186,8 +186,7 @@ class Airbrake(object):
         exc_info = (exception_class, exception, trace)
         error = Error(exc_info=exc_info)
         self.notify(error)
-        self.log(error)
-        self.excepthook(exc_info)
+        self.excepthook(*exc_info)
 
     def log(self, exc_info=None, message=None, filename=None,
             line=None, function=None, errtype=None, **params):

--- a/airbrake/notifier.py
+++ b/airbrake/notifier.py
@@ -181,12 +181,13 @@ class Airbrake(object):
                 self.host, self.project_id)
         return self._deploy_url
 
-    def uncaught_handler(*exc_info):
+    def uncaught_handler(self, ex_cls, ex, tb):
+        exc_info = (ex_cls, ex, tb)
         error = Error(exc_info=exc_info)
         notice = self.build_notice(error)
         self.notify(error)
-        self.log(**error)
-        self.excepthook(*exc_info)
+        self.log(error)
+        self.excepthook(exc_info)
 
     def log(self, exc_info=None, message=None, filename=None,
             line=None, function=None, errtype=None, **params):

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -449,6 +449,7 @@ class TestAirbrakeNotifier(unittest.TestCase):
     def test_uncaught_exception(self):
         ab = Airbrake(project_id=1234, api_key='fake')
         self.preserved_syshook = False
+
         def early_exit_syshook(*exc_info):
             self.preserved_syshook = True
             return
@@ -459,7 +460,8 @@ class TestAirbrakeNotifier(unittest.TestCase):
             try:
                 raise Exception("raise to sys level")
             except Exception:
-                # nose wraps exceptions, so manually call the exception as if it was uncaught.
+                # nose wraps exceptions, so manually call the exception as
+                # if it was uncaught.
                 exc_info = sys.exc_info()
 
                 sys.excepthook(*exc_info)


### PR DESCRIPTION
Closes https://github.com/airbrake/airbrake-python/issues/84

Make sure uncaught exceptions are sent by default, and preserve backtraces.