### PR TITLE
TypeError: not all arguments converted during string formatting

### DIFF
--- a/airbrake/notice.py
+++ b/airbrake/notice.py
@@ -128,7 +128,7 @@ class Error(object):  # pylint: disable=too-few-public-methods
                 "unsupported 'exc_info' type. Should be a "
                 "3-piece tuple as returned by sys.exc_info(). "
                 "Invalid argument was %s"
-                % self.exc_info)
+                % str(self.exc_info))
 
 
 def format_backtrace(trace):

--- a/tests/test_notice.py
+++ b/tests/test_notice.py
@@ -1,7 +1,7 @@
-import unittest
 import sys
+import unittest
 
-from airbrake.notice import Notice, Error, format_backtrace, ErrorLevels
+from airbrake.notice import Error, ErrorLevels, Notice, format_backtrace
 from airbrake.utils import pytb_lastline
 
 
@@ -91,9 +91,11 @@ class TestNotice(unittest.TestCase):
             sys.exit()
         except SystemExit:
             # SystemExit will be passed up the chain
-            with self.assertRaisesRegexp(TypeError, "unsupported 'exc_info' type"):
+            with self.assertRaisesRegexp(TypeError,
+                                         "unsupported 'exc_info' type"):
                 exc_info = sys.exc_info()
-                error = Error(exc_info=exc_info)
+                Error(exc_info=exc_info)
+                self.fail("Should have failed to create Error")
 
     def test_payload_no_empty_keys(self):
         exception = Exception("This is a test")

--- a/tests/test_notice.py
+++ b/tests/test_notice.py
@@ -68,7 +68,7 @@ class TestNotice(unittest.TestCase):
     def test_create_notice_error(self):
         try:
             raise TypeError
-        except:
+        except TypeError:
             exc_info = sys.exc_info()
             error = Error(exc_info=exc_info)
             notice = Notice(error)
@@ -85,6 +85,15 @@ class TestNotice(unittest.TestCase):
             }
 
             self.assertEqual(expected_payload, notice.payload)
+
+    def test_notice_error_system_exit(self):
+        try:
+            sys.exit()
+        except SystemExit:
+            # SystemExit will be passed up the chain
+            with self.assertRaisesRegexp(TypeError, "unsupported 'exc_info' type"):
+                exc_info = sys.exc_info()
+                error = Error(exc_info=exc_info)
 
     def test_payload_no_empty_keys(self):
         exception = Exception("This is a test")


### PR DESCRIPTION
I have a Python service doing some native heavy lifting that occasionally hits a Flask timeout. When it does that it calls `sys.exit(1)`. Rather than get a sensible error message I have been receiving `TypeError: not all arguments converted during string formatting`. I add the included test which originally failed with:

```
======================================================================
ERROR: test_notice_error_system_exit (tests.test_notice.TestNotice)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/matt/src/public/airbrake-python/tests/test_notice.py", line 94, in test_notice_error_system_exit
    error = Error(exc_info=exc_info)
  File "/Users/matt/src/public/airbrake-python/airbrake/notice.py", line 131, in __init__
    % self.exc_info)
TypeError: not all arguments converted during string formatting
```

This is because `SystemExit` does not inherit from `Exception` and falls into this branch. It seems that this branch was attempting to use the `self.exc_info` tuple as a `%s`. I added a `str()` call to correct that.

This prevents the error in the Airbrake code but does convert the the `SystemExit` into a `TypeError`. That seems to be the intent of the original code. Perhaps `SystemExit` deserves special handing in this case to pass it along - that is the reason for not inheriting from `Exception` after all. Let me know if that would be preferred and I can do that instead.
 