### PR TITLE
Set TLS verify

### DIFF
--- a/airbrake/notifier.py
+++ b/airbrake/notifier.py
@@ -145,6 +145,9 @@ class Airbrake(object):
 
         self._exc_queue = utils.CheckableQueue()
 
+        self._ca_bundle = config.get("verify", os.getenv("AIRBRAKE_CA_BUNDLE"))
+
+
     def __repr__(self):
         """Return value for the repr function."""
         return ("Airbrake(project_id=%s, api_key=*****, environment=%s)"
@@ -356,7 +359,8 @@ class Airbrake(object):
                             sort_keys=True),
             headers=headers,
             params=api_key,
-            timeout=self.timeout)
+            timeout=self.timeout,
+            verify=self._ca_bundle)
         response.raise_for_status()
         return response
 
@@ -385,6 +389,7 @@ class Airbrake(object):
                                      sort_keys=True),
                                  headers=headers,
                                  params=api_key,
-                                 timeout=self.timeout)
+                                 timeout=self.timeout,
+                                 verify=self._ca_bundle)
         response.raise_for_status()
         return response

--- a/airbrake/notifier.py
+++ b/airbrake/notifier.py
@@ -385,12 +385,12 @@ class Airbrake(object):
         api_key = {'key': self.api_key}
 
         response = self._session.post(self.deploy_url,
-                                 data=json.dumps(
-                                     payload,
-                                     cls=utils.FailProofJSONEncoder,
-                                     sort_keys=True),
-                                 headers=headers,
-                                 params=api_key,
-                                 timeout=self.timeout)
+                                      data=json.dumps(
+                                          payload,
+                                          cls=utils.FailProofJSONEncoder,
+                                          sort_keys=True),
+                                      headers=headers,
+                                      params=api_key,
+                                      timeout=self.timeout)
         response.raise_for_status()
         return response


### PR DESCRIPTION
I set up Errbit in AWS and made the endpoint private for testing, then access the endpoint from EKS. I know we should always verify TLS, but as for especially testing, we should have an option to skip verification. Could you consider merging this feature?