### PR TITLE
Deprecate use of Python3.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2
 jobs:
-  build_all:
+  build:
     working_directory: ~/airbrake-python
     docker:
-      - image: randomknowledge/docker-pyenv-tox
+      - image: randomknowledge/docker-pyenv-tox:maintenance_update-versions
 
     steps:
       - checkout
@@ -15,11 +15,5 @@ jobs:
             virtualenv airbrake
             source airbrake/bin/activate
             pip install tox tox-pyenv
-            pyenv local 2.7.15 3.4.6 3.5.5
+            pyenv local 2.7.18 3.5.10
             tox -v --recreate
-
-workflows:
-  version: 2
-  commit:
-    jobs:
-      - build_all

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py,py27,py34,py35,style
+envlist = py,py27,py35,style
 
 [testenv]
 passenv = CIRCLECI


### PR DESCRIPTION
Python3.4 was EOL on 18 Mar 2019. Dependencies are broken.

If you are Python3.4 user please upgrade to Python3.6+ and migrate to [pybrake](https://github.com/airbrake/pybrake/).