### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ except Exception:
     logger.exception("Bad math.")
 ```
 
-By default, airbrake will catch and send uncaught exceptions. To avoid this behvaiour, use the send_uncaught_exc option:
+By default, airbrake will catch and send uncaught exceptions. To avoid this behaviour, use the send_uncaught_exc option:
 `logger = airbrake.getLogger(api_key=*****, project_id=12345, send_uncaught_exc=False)`
 
 ### setup for Airbrake On-Premise and other compatible back-ends (e.g. Errbit)

--- a/airbrake/handler.py
+++ b/airbrake/handler.py
@@ -100,7 +100,7 @@ def airbrake_error_from_logrecord(record):
     for key, val in list(vars(record).items()):
         if not hasattr(_FAKE_LOGRECORD, key):
             # handle attribute/field name collisions:
-            # logrecod attrs should not limit or take
+            # logrecord attrs should not limit or take
             # precedence over values specified in 'extra'
             if key in params:
                 # if key "already" in params -> is logrecord attr

--- a/airbrake/notifier.py
+++ b/airbrake/notifier.py
@@ -210,7 +210,7 @@ class Airbrake(object):
         :param params:      Payload field "params" which may contain any other
                             context related to the exception(s).
 
-        Exception info willl be read from sys.exc_info() if it is not
+        Exception info will be read from sys.exc_info() if it is not
         supplied. To prevent this behavior, pass exc_info=False.
         """
         if not utils.is_exc_info_tuple(exc_info):


### PR DESCRIPTION
There are small typos in:
- README.md
- airbrake/handler.py
- airbrake/notifier.py

Fixes:
- Should read `will` rather than `willl`.
- Should read `logrecord` rather than `logrecod`.
- Should read `behaviour` rather than `behvaiour`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md